### PR TITLE
test: radio样式优化 新增size尺寸

### DIFF
--- a/docs/.vitepress/src/sidebars/en.ts
+++ b/docs/.vitepress/src/sidebars/en.ts
@@ -48,7 +48,8 @@ export const sidebar = {
       items: [
         { text: 'Input', link: '/en/components/input' },
         { text: 'InputNumber', link: '/en/components/inputNumber' },
-        { text: 'Checkbox', link: '/en/components/checkbox' }
+        { text: 'Checkbox', link: '/en/components/checkbox' },
+        { text: 'Radio', link: '/en/components/radio' },
       ]
     },
     {

--- a/docs/.vitepress/src/sidebars/zh.ts
+++ b/docs/.vitepress/src/sidebars/zh.ts
@@ -48,7 +48,8 @@ export const sidebar = {
       items: [
         { text: 'Input 输入框', link: '/zh/components/input' },
         { text: 'InputNumber 计数器', link: '/zh/components/inputNumber' },
-        { text: 'Checkbox 多选框', link: '/zh/components/checkbox' }
+        { text: 'Checkbox 多选框', link: '/zh/components/checkbox' },
+        { text: 'Radio 单选框', link: '/zh/components/radio' },
       ]
     },
     {

--- a/docs/.vitepress/theme/style/global.scss
+++ b/docs/.vitepress/theme/style/global.scss
@@ -131,6 +131,9 @@ $dark-border-color: #8a8a8e; // 暗黑边框题色
       .dk-input_pend{
         background-color: var(--vp-c-bg);
         border-color: var(--vp-c-border);
+        &:focus-within{
+          border-color: #409eff;
+        }
       }
       .dk-input-wrapper.dk-input_warning{
         border-color: var(--input-border);

--- a/docs/en/components/radio.md
+++ b/docs/en/components/radio.md
@@ -1,0 +1,252 @@
+# Radio
+
+In the given set of options, **single select**. The difference between `Checkbox` and `Checkbox` is that radio boxes are generally used in scenarios where **status changes and submission** is required.
+
+- [source code](https://github.com/dk-plus-ui/dk-plus-ui/tree/master/packages/components/radio)
+- [documents editing](https://github.com/dk-plus-ui/dk-plus-ui/blob/master/docs/en/components/radio.md)
+
+## <a id='Basicusage'>Basic usage</a>
+
+`label` is the copy of the radio box, `name` is the true value of the radio box, and `v-model` is the bound value.
+
+::: module
+<template #code>
+
+<div class='box'>
+  <div class='box-item'>
+    <dk-radio v-model='checked' size='large' label='option1(large)' name='option1(large)'></dk-radio>
+    <dk-radio size='medium' label='option2(medium)' name='option2(medium)'></dk-radio>
+    <dk-radio size='small' label='option3(small)' name='option3(small)'></dk-radio>
+    <dk-radio size='mini' label='option4(mini)' name='option4(mini)'></dk-radio>
+  </div>
+  <div class='box-item'>
+    <dk-radio disabled label='option1' name='option1'></dk-radio>
+    <dk-radio disabled label='option2' name='option2'></dk-radio>
+    <dk-radio disabled label='option3' name='option3'></dk-radio>
+    <dk-radio disabled label='option4' name='option4'></dk-radio>
+  </div>
+</div>
+</template>
+
+```vue
+<template>
+  <div class="box">
+    <div class="box-item">
+      <dk-radio
+        v-model="checked"
+        size="large"
+        label="option1(large)"
+        name="option1(large)"
+      ></dk-radio>
+      <dk-radio size="medium" label="option2(medium)" name="option2(medium)"></dk-radio>
+      <dk-radio size="small" label="option3(small)" name="option3(small)"></dk-radio>
+      <dk-radio size="mini" label="option4(mini)" name="option4(mini)"></dk-radio>
+    </div>
+    <div class="box-item">
+      <dk-radio disabled label="option1" name="option1"></dk-radio>
+      <dk-radio disabled label="option2" name="option2"></dk-radio>
+      <dk-radio disabled label="option3" name="option3"></dk-radio>
+      <dk-radio disabled label="option4" name="option4"></dk-radio>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    checked: 'option1(large)'
+  })
+  const { checked } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='Radio-Box-Group'>RadioBoxGroup</a>
+
+Using `dk-radio-group` can achieve radio box groups.
+
+::: module
+<template #code>
+<dk-radio-group v-model="groupValue">
+<dk-radio label="option 1" name="radio1" />
+<dk-radio label="option 2" name="radio2" />
+<dk-radio label="option 3" name="radio3" />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue" @change="handleGroupChange">
+    <dk-radio label="option 1" name="radio1" />
+    <dk-radio label="option 2" name="radio2" />
+    <dk-radio label="option 3" name="radio3" />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+  const handleGroupChange = (val: string) => {
+    console.log(val)
+  }
+</script>
+```
+
+:::
+
+## <a id='disabled'>disabled</a>
+
+Disable the radio box through the `disabled` attribute.
+
+::: module
+<template #code>
+<dk-radio-group v-model="disabledGroupValue">
+<dk-radio label="option 1" name="radio1" />
+<dk-radio label="option 2" name="radio2" />
+<dk-radio label="option 3" name="radio3" disabled />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" />
+    <dk-radio label="option 2" name="radio2" />
+    <dk-radio label="option 3" name="radio3" disabled />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='border'>border</a>
+
+Set a radio box with a border through the `border` attribute.
+
+::: module
+<template #code>
+<dk-radio-group v-model="borderGroupValue">
+<dk-radio label="option 1" name="radio1" border />
+<dk-radio label="option 2" name="radio2" border />
+<dk-radio label="option 3" name="radio3" border />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" border />
+    <dk-radio label="option 2" name="radio2" border />
+    <dk-radio label="option 3" name="radio3" border />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='size'>size</a>
+
+Through the `size` property to set the size of the radio box, support `large`, `medium`, `small`, `mini`, default `small`.
+
+::: module
+<template #code>
+<dk-radio-group v-model="sizeGroupValue">
+<dk-radio label="option 1" name="radio1" size="large" />
+<dk-radio label="option 2" name="radio2" size="medium" />
+<dk-radio label="option 3" name="radio3" size="small" />
+<dk-radio label="option 4" name="radio4" size="mini" />
+</dk-radio-group>
+
+<div style='margin-top: 20px'></div>
+<dk-radio-group v-model="sizeGroupValue">
+<dk-radio label="option 1" name="radio1" border size="large" />
+<dk-radio label="option 2" name="radio2" border size="medium" />
+<dk-radio label="option 3" name="radio3" border size="small" />
+<dk-radio label="option 4" name="radio4" border size="mini" />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" size="large" />
+    <dk-radio label="option 2" name="radio2" size="medium" />
+    <dk-radio label="option 3" name="radio3" size="small" />
+    <dk-radio label="option 4" name="radio4" size="mini" />
+  </dk-radio-group>
+  <dk-radio-group v-model="sizeGroupValue">
+    <dk-radio label="option 1" name="radio1" border size="large" />
+    <dk-radio label="option 2" name="radio2" border size="medium" />
+    <dk-radio label="option 3" name="radio3" border size="small" />
+    <dk-radio label="option 4" name="radio4" border size="mini" />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='attribute'>attribute</a>
+
+| parameter         | explain                                                                      | type      | Optional values                 | Default value |
+| ----------------- | ---------------------------------------------------------------------------- | --------- | ------------------------------- | ------------- |
+| `v-model`         | [Binding value](#Basicusage)                                                 | `string`  | -                               | -             |
+| `label`           | [Radio Box Copy](#Basicusage)                                                | `string`  | -                               | -             |
+| `name`            | [The true value of the radio box(Do not set default to`label`)](#Basicusage) | `string`  | -                               | -             |
+| `size`            | [The size of the radio box](#size)                                           | `string`  | `large` `medium` `small` `mini` | `small`       |
+| `disabled`        | [Is it disabled](#disabled)                                                  | `boolean` | `true` `false`                  | `false`       |
+| `border`          | [Is there a border](#border)                                                 | `boolean` | `true` `false`                  | `false`       |
+| `checked-color`   | Color when selected                                                          | `string`  | -                               | `#409eff`     |
+| `unchecked-color` | Color when not selected                                                      | `string`  | -                               | `#c0ccda`     |
+
+## <a id='Events'>Events</a>
+
+| Event Name | explain                      | Callback Arguments         |
+| ---------- | ---------------------------- | -------------------------- |
+| `change`   | [Binding value](#Basicusage) | `(value: string) => value` |
+
+## <a id='RadioGroupAttribute'>RadioGroup attribute</a>
+
+| parameter | explain                           | type     | Optional values | Default value |
+| --------- | --------------------------------- | -------- | --------------- | ------------- |
+| `v-model` | [Binding value](#Radio-Box-Group) | `string` | -               | -             |
+
+## <a id='RadioGroupEvents'>RadioGroup Events</a>
+
+| Event Name | explain                           | Callback Arguments         |
+| ---------- | --------------------------------- | -------------------------- |
+| `change`   | [Binding value](#Radio-Box-Group) | `(value: string) => value` |
+
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    checked: 'option1(large)',
+    groupValue: 'option 1',
+    disabledGroupValue: 'option 1',
+    borderGroupValue: 'option 1',
+    sizeGroupValue: 'option 1'
+  })
+  const { checked, groupValue, disabledGroupValue, borderGroupValue, sizeGroupValue } = toRefs(data)
+</script>

--- a/docs/zh/components/radio.md
+++ b/docs/zh/components/radio.md
@@ -1,0 +1,252 @@
+# Radio 单选框
+
+在给定的一组选项中**单选**。和 `Checkbox` 的区别是，单选框一般用在**状态改变后需要提交**的场景。
+
+- [源代码](https://github.com/dk-plus-ui/dk-plus-ui/tree/master/packages/components/radio)
+- [文档编辑](https://github.com/dk-plus-ui/dk-plus-ui/blob/master/docs/zh/components/radio.md)
+
+## <a id='基础用法'>基础用法</a>
+
+`label` 为单选框的文案，`name` 为单选框的真实值，`v-model` 为绑定值。
+
+::: module
+<template #code>
+
+<div class='box'>
+  <div class='box-item'>
+    <dk-radio v-model='checked' size='large' label='option1(large)' name='option1(large)'></dk-radio>
+    <dk-radio size='medium' label='option2(medium)' name='option2(medium)'></dk-radio>
+    <dk-radio size='small' label='option3(small)' name='option3(small)'></dk-radio>
+    <dk-radio size='mini' label='option4(mini)' name='option4(mini)'></dk-radio>
+  </div>
+  <div class='box-item'>
+    <dk-radio disabled label='option1' name='option1'></dk-radio>
+    <dk-radio disabled label='option2' name='option2'></dk-radio>
+    <dk-radio disabled label='option3' name='option3'></dk-radio>
+    <dk-radio disabled label='option4' name='option4'></dk-radio>
+  </div>
+</div>
+</template>
+
+```vue
+<template>
+  <div class="box">
+    <div class="box-item">
+      <dk-radio
+        v-model="checked"
+        size="large"
+        label="option1(large)"
+        name="option1(large)"
+      ></dk-radio>
+      <dk-radio size="medium" label="option2(medium)" name="option2(medium)"></dk-radio>
+      <dk-radio size="small" label="option3(small)" name="option3(small)"></dk-radio>
+      <dk-radio size="mini" label="option4(mini)" name="option4(mini)"></dk-radio>
+    </div>
+    <div class="box-item">
+      <dk-radio disabled label="option1" name="option1"></dk-radio>
+      <dk-radio disabled label="option2" name="option2"></dk-radio>
+      <dk-radio disabled label="option3" name="option3"></dk-radio>
+      <dk-radio disabled label="option4" name="option4"></dk-radio>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    checked: 'option1(large)'
+  })
+  const { checked } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='单选框组'>单选框组</a>
+
+使用 `dk-radio-group` 可以实现单选框组。
+
+::: module
+<template #code>
+<dk-radio-group v-model="groupValue">
+<dk-radio label="option 1" name="radio1" />
+<dk-radio label="option 2" name="radio2" />
+<dk-radio label="option 3" name="radio3" />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue" @change="handleGroupChange">
+    <dk-radio label="option 1" name="radio1" />
+    <dk-radio label="option 2" name="radio2" />
+    <dk-radio label="option 3" name="radio3" />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+  const handleGroupChange = (val: string) => {
+    console.log(val)
+  }
+</script>
+```
+
+:::
+
+## <a id='禁用状态'>禁用状态</a>
+
+通过 `disabled` 属性来禁用单选框。
+
+::: module
+<template #code>
+<dk-radio-group v-model="disabledGroupValue">
+<dk-radio label="option 1" name="radio1" />
+<dk-radio label="option 2" name="radio2" />
+<dk-radio label="option 3" name="radio3" disabled />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" />
+    <dk-radio label="option 2" name="radio2" />
+    <dk-radio label="option 3" name="radio3" disabled />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='带有边框的单选框'>带有边框的单选框</a>
+
+通过 `border` 属性来设置带有边框的单选框。
+
+::: module
+<template #code>
+<dk-radio-group v-model="borderGroupValue">
+<dk-radio label="option 1" name="radio1" border />
+<dk-radio label="option 2" name="radio2" border />
+<dk-radio label="option 3" name="radio3" border />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" border />
+    <dk-radio label="option 2" name="radio2" border />
+    <dk-radio label="option 3" name="radio3" border />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='尺寸'>尺寸</a>
+
+通过 `size` 属性来设置单选框的尺寸, 支持 `large`、`medium`、`small`、`mini`, 默认 `small`。
+
+::: module
+<template #code>
+<dk-radio-group v-model="sizeGroupValue">
+<dk-radio label="option 1" name="radio1" size="large" />
+<dk-radio label="option 2" name="radio2" size="medium" />
+<dk-radio label="option 3" name="radio3" size="small" />
+<dk-radio label="option 4" name="radio4" size="mini" />
+</dk-radio-group>
+
+<div style='margin-top: 20px'></div>
+<dk-radio-group v-model="sizeGroupValue">
+<dk-radio label="option 1" name="radio1" border size="large" />
+<dk-radio label="option 2" name="radio2" border size="medium" />
+<dk-radio label="option 3" name="radio3" border size="small" />
+<dk-radio label="option 4" name="radio4" border size="mini" />
+</dk-radio-group>
+</template>
+
+```vue
+<template>
+  <dk-radio-group v-model="groupValue">
+    <dk-radio label="option 1" name="radio1" size="large" />
+    <dk-radio label="option 2" name="radio2" size="medium" />
+    <dk-radio label="option 3" name="radio3" size="small" />
+    <dk-radio label="option 4" name="radio4" size="mini" />
+  </dk-radio-group>
+  <dk-radio-group v-model="sizeGroupValue">
+    <dk-radio label="option 1" name="radio1" border size="large" />
+    <dk-radio label="option 2" name="radio2" border size="medium" />
+    <dk-radio label="option 3" name="radio3" border size="small" />
+    <dk-radio label="option 4" name="radio4" border size="mini" />
+  </dk-radio-group>
+</template>
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    groupValue: 'option 1'
+  })
+  const { groupValue } = toRefs(data)
+</script>
+```
+
+:::
+
+## <a id='属性'>属性</a>
+
+| 参数              | 说明                                             | 类型      | 可选值                          | 默认值    |
+| ----------------- | ------------------------------------------------ | --------- | ------------------------------- | --------- |
+| `v-model`         | [绑定值](#基础用法)                              | `string`  | -                               | -         |
+| `label`           | [单选框文案](#基础用法)                          | `string`  | -                               | -         |
+| `name`            | [单选框的真实值(不设置默认为`label`)](#基础用法) | `string`  | -                               | -         |
+| `size`            | [单选框的大小](#尺寸)                            | `string`  | `large` `medium` `small` `mini` | `small`   |
+| `disabled`        | [是否禁用](#禁用状态)                            | `boolean` | `true` `false`                  | `false`   |
+| `border`          | [是否带有边框](#带有边框的单选框)                | `boolean` | `true` `false`                  | `false`   |
+| `checked-color`   | 选中时的颜色                                     | `string`  | -                               | `#409eff` |
+| `unchecked-color` | 未选中时的颜色                                   | `string`  | -                               | `#c0ccda` |
+
+## <a id='事件'>事件</a>
+
+| 事件名   | 说明                | 回调参数                   |
+| -------- | ------------------- | -------------------------- |
+| `change` | [绑定值](#基础用法) | `(value: string) => value` |
+
+## <a id='RadioGroup属性'>RadioGroup 属性</a>
+
+| 参数      | 说明                | 类型     | 可选值 | 默认值 |
+| --------- | ------------------- | -------- | ------ | ------ |
+| `v-model` | [绑定值](#单选框组) | `string` | -      | -      |
+
+## <a id='RadioGroup事件'>RadioGroup 事件</a>
+
+| 事件名   | 说明                | 回调参数                   |
+| -------- | ------------------- | -------------------------- |
+| `change` | [绑定值](#单选框组) | `(value: string) => value` |
+
+<script setup lang="ts">
+  import { reactive, toRefs } from 'vue'
+  const data = reactive({
+    checked: 'option1(large)',
+    groupValue: 'option 1',
+    disabledGroupValue: 'option 1',
+    borderGroupValue: 'option 1',
+    sizeGroupValue: 'option 1'
+  })
+  const { checked, groupValue, disabledGroupValue, borderGroupValue, sizeGroupValue } = toRefs(data)
+</script>

--- a/packages/components/_hooks/get-checkbox/index.ts
+++ b/packages/components/_hooks/get-checkbox/index.ts
@@ -16,6 +16,7 @@ export const getCheckbox = (prop: DkCheckboxType): CheckboxType => {
   }
 
   const classList = classes([...defaultClassList], 'dk-checkbox')
+  
   const styleList = (): CSSProperties => {
     const { size } = prop
     const targetSize: Record<string, string> = {

--- a/packages/components/_hooks/get-radio-group/index.ts
+++ b/packages/components/_hooks/get-radio-group/index.ts
@@ -1,0 +1,21 @@
+import { type ComponentOptions, toRaw, type Slots } from 'vue'
+import type { DkRadioGroupPropsType } from '../../dkradio_group/src/props';
+import { getSlotList } from '../public/get-slot-list';
+
+interface GetRadioGroupType {
+  getSlot: Function
+}
+
+export const getRadioGroup = (props: DkRadioGroupPropsType): GetRadioGroupType => {
+  const data = toRaw(props);
+  data
+  
+  const getSlot = (slots: Slots): ComponentOptions[] => {
+    const list = getSlotList(slots, 'DkRadio');
+    return list;
+  }
+
+  return {
+    getSlot
+  }
+}

--- a/packages/components/_hooks/get-radio/index.ts
+++ b/packages/components/_hooks/get-radio/index.ts
@@ -18,7 +18,7 @@ export const getRadio = (props: DkRadioType): RadioReturnsType => {
   const classList = classes([...defaultClassList], 'dk-radio')
 
   const styleList = (): CSSProperties => {
-    const { size } = data
+    const { size, checkedColor, uncheckedColor } = data
     const targetSize: Record<string, string> = {
       large: '18px',
       medium: '16px',
@@ -27,7 +27,9 @@ export const getRadio = (props: DkRadioType): RadioReturnsType => {
     }
     
     const style: CSSProperties = {
-      '--radio-size': targetSize[size] || targetSize['small']
+      '--radio-size': targetSize[size] || targetSize['small'],
+      '--radio-checked-color': checkedColor || '#409eff',
+      '--radio-unchecked-color': uncheckedColor || '#dcdfe6'
     }
     return {
       ...style

--- a/packages/components/_hooks/get-radio/index.ts
+++ b/packages/components/_hooks/get-radio/index.ts
@@ -1,7 +1,7 @@
 import type { DkRadioType } from '../../dkradio/src/props'
 import { toRaw, type ComputedRef, type CSSProperties } from 'vue'
 import type { ClassListName } from '../../_interface'
-import { getStyleList } from '..'
+import { getColor, getStyleList } from '..'
 
 interface RadioReturnsType {
   classList: ComputedRef<ClassListName>
@@ -29,7 +29,8 @@ export const getRadio = (props: DkRadioType): RadioReturnsType => {
     const style: CSSProperties = {
       '--radio-size': targetSize[size] || targetSize['small'],
       '--radio-checked-color': checkedColor || '#409eff',
-      '--radio-unchecked-color': uncheckedColor || '#dcdfe6'
+      '--radio-unchecked-color': uncheckedColor || '#dcdfe6',
+      '--radio-hover-color': getColor(checkedColor || '#dcdfe6').getDeepen(0.1)
     }
     return {
       ...style

--- a/packages/components/_hooks/get-radio/index.ts
+++ b/packages/components/_hooks/get-radio/index.ts
@@ -1,0 +1,41 @@
+import type { DkRadioType } from '../../dkradio/src/props'
+import { toRaw, type ComputedRef, type CSSProperties } from 'vue'
+import type { ClassListName } from '../../_interface'
+import { getStyleList } from '..'
+
+interface RadioReturnsType {
+  classList: ComputedRef<ClassListName>
+  styleList: CSSProperties
+}
+
+export const getRadio = (props: DkRadioType): RadioReturnsType => {
+  const data = toRaw(props)
+
+  const { classes } = getStyleList(data, 'radio')
+
+  const defaultClassList: string[] = ['disabled', 'border']
+
+  const classList = classes([...defaultClassList], 'dk-radio')
+
+  const styleList = (): CSSProperties => {
+    const { size } = data
+    const targetSize: Record<string, string> = {
+      large: '18px',
+      medium: '16px',
+      small: '14px',
+      mini: '12px'
+    }
+    
+    const style: CSSProperties = {
+      '--radio-size': targetSize[size] || targetSize['small']
+    }
+    return {
+      ...style
+    }
+  }
+
+  return {
+    classList,
+    styleList: styleList()
+  }
+}

--- a/packages/components/_hooks/get-switch/index.ts
+++ b/packages/components/_hooks/get-switch/index.ts
@@ -1,0 +1,46 @@
+import { toRaw, type CSSProperties, type ComputedRef } from 'vue'
+import type { SwitchPropsType } from '../../dkswitch/src/props'
+import { getStyleList } from '..'
+import type { ClassListName } from '../../_interface'
+
+interface GetSwitchReturnsType {
+  classList: ComputedRef<ClassListName>
+  styleList: CSSProperties
+}
+
+export const getSwitch = (props: SwitchPropsType): GetSwitchReturnsType => {
+  const data = toRaw(props)
+  data
+
+  const { classes } = getStyleList(data, 'switch')
+
+  const defaultClass = ['dk-switch', 'disabled']
+
+  const classList = classes([...defaultClass], 'dk-switch')
+
+  const styleList = (): CSSProperties => {
+    const {
+      size
+    } = data
+
+    const targetSize: Record<string, string> = {
+      large: '56px',
+      medium: '48px',
+      small: '40px',
+      mini: '36px'
+    }
+
+    const style = {
+      '--switch-size': targetSize[size] || targetSize['small']
+    }
+
+    return {
+      ...style
+    }
+  }
+
+  return {
+    classList,
+    styleList: styleList()
+  }
+}

--- a/packages/components/_hooks/get-switch/index.ts
+++ b/packages/components/_hooks/get-switch/index.ts
@@ -1,6 +1,6 @@
 import { toRaw, type CSSProperties, type ComputedRef } from 'vue'
 import type { SwitchPropsType } from '../../dkswitch/src/props'
-import { getStyleList } from '..'
+import { getColor, getStyleList } from '..'
 import type { ClassListName } from '../../_interface'
 
 interface GetSwitchReturnsType {
@@ -19,9 +19,7 @@ export const getSwitch = (props: SwitchPropsType): GetSwitchReturnsType => {
   const classList = classes([...defaultClass], 'dk-switch')
 
   const styleList = (): CSSProperties => {
-    const {
-      size
-    } = data
+    const { size, checkedColor, uncheckedColor } = data
 
     const targetSize: Record<string, string> = {
       large: '56px',
@@ -31,7 +29,9 @@ export const getSwitch = (props: SwitchPropsType): GetSwitchReturnsType => {
     }
 
     const style = {
-      '--switch-size': targetSize[size] || targetSize['small']
+      '--switch-size': targetSize[size] || targetSize['small'],
+      '--switch-checked-color': getColor(checkedColor || '#409EFF').getDeepen(0),
+      '--switch-unchecked-color': getColor(uncheckedColor || '#C0CCDA').getDeepen(0)
     }
 
     return {

--- a/packages/components/_hooks/get-switch/index.ts
+++ b/packages/components/_hooks/get-switch/index.ts
@@ -2,6 +2,7 @@ import { toRaw, type CSSProperties, type ComputedRef } from 'vue'
 import type { SwitchPropsType } from '../../dkswitch/src/props'
 import { getColor, getStyleList } from '..'
 import type { ClassListName } from '../../_interface'
+import { setSize } from '..'
 
 interface GetSwitchReturnsType {
   classList: ComputedRef<ClassListName>
@@ -19,17 +20,28 @@ export const getSwitch = (props: SwitchPropsType): GetSwitchReturnsType => {
   const classList = classes([...defaultClass], 'dk-switch')
 
   const styleList = (): CSSProperties => {
-    const { size, checkedColor, uncheckedColor } = data
+    const { size, checkedColor, uncheckedColor, width } = data
 
-    const targetSize: Record<string, string> = {
-      large: '56px',
-      medium: '48px',
-      small: '40px',
-      mini: '36px'
+    const targetSize: Record<string, string[]> = {
+      large: ['56px', '28px'],
+      medium: ['48px', '24px'],
+      small: ['40px', '20px'],
+      mini: ['36px', '18px']
+    }
+
+    let switchWidth = size
+      ? targetSize[size][0] || targetSize['small'][0]
+      : targetSize['small'][0]
+
+    if (width) {
+      switchWidth = setSize(width || '40px')
     }
 
     const style = {
-      '--switch-size': targetSize[size] || targetSize['small'],
+      '--switch-width': switchWidth,
+      '--switch-height': size
+        ? targetSize[size][1] || targetSize['small'][1]
+        : targetSize['small'][1],
       '--switch-checked-color': getColor(checkedColor || '#409EFF').getDeepen(0),
       '--switch-unchecked-color': getColor(uncheckedColor || '#C0CCDA').getDeepen(0)
     }

--- a/packages/components/_hooks/get-switch/index.ts
+++ b/packages/components/_hooks/get-switch/index.ts
@@ -1,8 +1,7 @@
 import { toRaw, type CSSProperties, type ComputedRef } from 'vue'
 import type { SwitchPropsType } from '../../dkswitch/src/props'
-import { getColor, getStyleList } from '..'
+import { getColor, getStyleList, setSize } from '..'
 import type { ClassListName } from '../../_interface'
-import { setSize } from '..'
 
 interface GetSwitchReturnsType {
   classList: ComputedRef<ClassListName>
@@ -29,16 +28,11 @@ export const getSwitch = (props: SwitchPropsType): GetSwitchReturnsType => {
       mini: ['36px', '18px']
     }
 
-    let switchWidth = size
-      ? targetSize[size][0] || targetSize['small'][0]
-      : targetSize['small'][0]
-
-    if (width) {
-      switchWidth = setSize(width || '40px')
-    }
-
     const style = {
-      '--switch-width': switchWidth,
+      '--switch-width': width ? setSize(width) : 'fit-content',
+      '--switch-min-width': size
+        ? targetSize[size][0] || targetSize['small'][0]
+        : targetSize['small'][0],
       '--switch-height': size
         ? targetSize[size][1] || targetSize['small'][1]
         : targetSize['small'][1],

--- a/packages/components/_hooks/index.ts
+++ b/packages/components/_hooks/index.ts
@@ -13,6 +13,7 @@
  * get-collapse collapse用的hooks
  * get-radio radio用的hooks
  * get-radio-group radio-group用的hooks
+ * get-switch switch用的hooks
  * **************公共hooks(public)**************
  * get-color   颜色用的hooks (getColor)
  * get-Global  全局用的hooks  (getGlobal)
@@ -44,3 +45,4 @@ export * from './get-checkbox-group'
 export * from './get-collapse'
 export * from './get-radio'
 export * from './get-radio-group'
+export * from './get-switch'

--- a/packages/components/_hooks/index.ts
+++ b/packages/components/_hooks/index.ts
@@ -11,6 +11,7 @@
  * get-alert   alert用的hooks
  * get-checkbox-group checkbox-group用的hooks
  * get-collapse collapse用的hooks
+ * get-radio radio用的hooks
  * **************公共hooks(public)**************
  * get-color   颜色用的hooks (getColor)
  * get-Global  全局用的hooks  (getGlobal)
@@ -40,3 +41,4 @@ export * from './get-checkbox'
 export * from './public/get-slot-list'
 export * from './get-checkbox-group'
 export * from './get-collapse'
+export * from './get-radio'

--- a/packages/components/_hooks/index.ts
+++ b/packages/components/_hooks/index.ts
@@ -12,6 +12,7 @@
  * get-checkbox-group checkbox-group用的hooks
  * get-collapse collapse用的hooks
  * get-radio radio用的hooks
+ * get-radio-group radio-group用的hooks
  * **************公共hooks(public)**************
  * get-color   颜色用的hooks (getColor)
  * get-Global  全局用的hooks  (getGlobal)
@@ -42,3 +43,4 @@ export * from './public/get-slot-list'
 export * from './get-checkbox-group'
 export * from './get-collapse'
 export * from './get-radio'
+export * from './get-radio-group'

--- a/packages/components/_utils/props/index.ts
+++ b/packages/components/_utils/props/index.ts
@@ -148,3 +148,31 @@ export const setFunction = <T extends Function>(
     default: () => defaultVal
   } as const
 }
+
+/**
+ * @name setColorProp
+ * @Time September 8, 2023
+ * @param { string } color
+ * @returns Set the color type props parameter
+ * @default null
+ */
+export const setColorProp = (
+  color?: string | null
+): { type: StringConstructor; default: () => string | null } => {
+  const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+  const rgbRegex = /^rgb\((\d{1,3}),(\d{1,3}),(\d{1,3})\)$/
+  const rgbaRegex = /^rgba\((\d{1,3}),(\d{1,3}),(\d{1,3}),([01](\.\d+)?)\)$/
+
+  return {
+    type: String,
+    default: (): string | null => {
+      if (
+        color &&
+        (hexRegex.test(color) || rgbRegex.test(color) || rgbaRegex.test(color))
+      ) {
+        return color
+      }
+      return null
+    }
+  }
+}

--- a/packages/components/components.ts
+++ b/packages/components/components.ts
@@ -69,3 +69,6 @@ export * from './dkradio'
 
 export { DkRadioGroup } from './dkradio_group'
 export * from './dkradio_group'
+
+export { DkSwitch } from './dkswitch'
+export * from './dkswitch'

--- a/packages/components/components.ts
+++ b/packages/components/components.ts
@@ -66,3 +66,6 @@ export * from './dkcheckbox_group'
 
 export { DkRadio } from './dkradio'
 export * from './dkradio'
+
+export { DkRadioGroup } from './dkradio_group'
+export * from './dkradio_group'

--- a/packages/components/dkcodedisplay/src/setPosition.ts
+++ b/packages/components/dkcodedisplay/src/setPosition.ts
@@ -36,13 +36,19 @@ export class SetPosition {
 
       // Button position exceeds viewport height
       const isOverTop = buttonOffset > innerHeight
-      const isOffsetOverTop =  targetDom.offsetTop - scrollTop + dkCodeDisplayCodeDom.clientHeight < innerHeight
+      
+      const isOffsetOverTop =
+        targetDom.offsetTop -
+          scrollTop +
+          dkCodeDisplayCodeDom.clientHeight -
+          (targetDom.clientHeight / 2) <
+        innerHeight
       
       if (
-        isOverTop &&
         isOffsetOverTop &&
-        this.open
-      ) {
+        isOverTop
+        ) {
+        // this.open
         const firstParent = targetDom.parentNode as HTMLElement
         const vpDocDom = firstParent.parentNode as HTMLElement
         const mainDom = vpDocDom.parentNode as HTMLElement

--- a/packages/components/dkradio/src/props.ts
+++ b/packages/components/dkradio/src/props.ts
@@ -1,5 +1,5 @@
 import type { ExtractPropTypes } from 'vue'
-import { setBooleanProps, setStringProp } from '../../_utils'
+import { setBooleanProps, setStringProp, setColorProp } from '../../_utils'
 import { DK_SIZE } from '../../_tokens'
 import type { dkPlusSize } from '../../_interface'
 export const dkRadioProps = {
@@ -34,11 +34,11 @@ export const dkRadioProps = {
    * @param { string }  [small]
    * @param { string }  [mini]
    */
-  size: setStringProp<dkPlusSize>(null, (value: dkPlusSize): boolean => {
-    return DK_SIZE.includes(value)
-  })
-  // checkedColor: String,
-  // uncheckedColor: String
+  size: setStringProp<dkPlusSize>(null, (val: dkPlusSize) => {
+    return DK_SIZE.includes(val)
+  }),
+  checkedColor: setColorProp(),
+  uncheckedColor: setColorProp()
 }
 
 export type DkRadioType = ExtractPropTypes<typeof dkRadioProps>

--- a/packages/components/dkradio/src/props.ts
+++ b/packages/components/dkradio/src/props.ts
@@ -37,8 +37,27 @@ export const dkRadioProps = {
   size: setStringProp<dkPlusSize>(null, (val: dkPlusSize) => {
     return DK_SIZE.includes(val)
   }),
+  /**
+   * @name checkedColor
+   * @param { string } checkedColor  [null]
+   * @description Color when selected
+   * @default null
+   */
   checkedColor: setColorProp(),
-  uncheckedColor: setColorProp()
+  /**
+   * @name uncheckedColor
+   * @param { string } uncheckedColor  [null]
+   * @description Color when unselected
+   */
+  uncheckedColor: setColorProp(),
+  /**
+   * @name border
+   * @param { boolean } border  [false]
+   * @description Whether to display border
+   * @default false
+   * @type boolean
+   */
+  border: setBooleanProps(false)
 }
 
 export type DkRadioType = ExtractPropTypes<typeof dkRadioProps>

--- a/packages/components/dkradio/src/radio.vue
+++ b/packages/components/dkradio/src/radio.vue
@@ -28,8 +28,10 @@
 
       const methods = {
         handleChange: (): void => {
-          emit('update:modelValue', data.name)
-          emit('change', data.name)
+          let value = data.name || data.label
+
+          emit('update:modelValue', value)
+          emit('change', value)
         }
       }
 

--- a/packages/components/dkradio/src/radio.vue
+++ b/packages/components/dkradio/src/radio.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { defineComponent, reactive, toRefs, watch, ref, nextTick } from 'vue'
   import { dkRadioProps } from './props'
+  import { getRadio } from '../../_hooks'
   export default defineComponent({
     name: 'DkRadio',
     props: dkRadioProps,
@@ -8,25 +9,25 @@
     setup(props, { emit }) {
       const radio = ref<HTMLInputElement>()
 
-      const getClassList = (): string[] => {
-        const list = ['dk-radio']
-        if (props.disabled) {
-          list.push('dk-radio_disabled')
-        }
-        return list
-      }
+      // const getClassList = (): string[] => {
+      //   const list = ['dk-radio']
+      //   if (props.disabled) {
+      //     list.push('dk-radio_disabled')
+      //   }
+      //   return list
+      // }
 
       const data = reactive({
         name: props.name,
         check: props.modelValue,
         disabled: props.disabled,
-        label: props.label,
-        classList: getClassList()
+        label: props.label
       })
+
+      const { classList, styleList } = getRadio(props)
 
       const methods = {
         handleChange: (): void => {
-          // const target = e.target as HTMLInputElement;
           emit('update:modelValue', data.name)
           emit('change', data.name)
         }
@@ -48,16 +49,18 @@
       return {
         radio,
         ...toRefs(data),
-        ...methods
+        ...methods,
+        classList,
+        styleList
       }
     }
   })
 </script>
 <template>
-  <div :class="classList">
+  <div :class="classList" :style="styleList">
     <label class="dk-radio-wrapper" @change="handleChange">
-      <div class="dk-radio_circle"></div>
       <input ref="radio" class="dk-radio_inner" type="radio" :disabled="disabled" />
+      <div class="dk-radio_circle"></div>
       <span>{{ label }}</span>
     </label>
   </div>

--- a/packages/components/dkradio_group/index.ts
+++ b/packages/components/dkradio_group/index.ts
@@ -1,0 +1,7 @@
+import radioGroup from './src/radioGroup.vue';
+
+import { withInstall } from '../_utils/index';
+
+export const DkRadioGroup = withInstall(radioGroup);
+
+export type radioGroupInstance = InstanceType<typeof radioGroup>;

--- a/packages/components/dkradio_group/src/props.ts
+++ b/packages/components/dkradio_group/src/props.ts
@@ -1,0 +1,8 @@
+import type { ExtractPropTypes } from 'vue'
+import { setStringProp } from '../../_utils'
+
+export const DkRadioGroupProps = {
+  modelValue: setStringProp()
+}
+
+export type DkRadioGroupPropsType = ExtractPropTypes<typeof DkRadioGroupProps>

--- a/packages/components/dkradio_group/src/radioGroup.vue
+++ b/packages/components/dkradio_group/src/radioGroup.vue
@@ -36,19 +36,15 @@
 </script>
 <template>
   <div class="dk-radio-group">
-    <div class="dk-radio-group__inner">
-      <div class="dk-radio-group__content">
-        <div class="dk-radio-group__list">
-          <div v-for="item in slotList" :key="item.name" class="dk-radio-group__item">
-            <dk-radio
-              v-model="checkValue"
-              :label="item.label"
-              :name="item.name"
-              v-bind="item"
-              @change="handleChange"
-            />
-          </div>
-        </div>
+    <div class="dk-radio-group_list">
+      <div v-for="item in slotList" :key="item.name" class="dk-radio-group__item">
+        <dk-radio
+          v-model="checkValue"
+          :label="item.label"
+          :name="item.name"
+          v-bind="item"
+          @change="handleChange"
+        />
       </div>
     </div>
   </div>

--- a/packages/components/dkradio_group/src/radioGroup.vue
+++ b/packages/components/dkradio_group/src/radioGroup.vue
@@ -9,7 +9,6 @@
     setup(props, { slots, emit }) {
       const { getSlot } = getRadioGroup(props)
       const slotList = getSlot(slots)
-      console.log(slotList)
 
       const checkValue = ref('radio2')
 

--- a/packages/components/dkradio_group/src/radioGroup.vue
+++ b/packages/components/dkradio_group/src/radioGroup.vue
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { defineComponent, ref, watch } from 'vue'
+  import { DkRadioGroupProps } from './props'
+  import { getRadioGroup } from '../../_hooks'
+  export default defineComponent({
+    name: 'DkRadioGroup',
+    props: DkRadioGroupProps,
+    emits: ['change', 'update:modelValue'],
+    setup(props, { slots, emit }) {
+      const { getSlot } = getRadioGroup(props)
+      const slotList = getSlot(slots)
+      console.log(slotList)
+
+      const checkValue = ref('radio2')
+
+      const handleChange = (name: string): void => {
+        checkValue.value = name
+        emit('change', name)
+        emit('update:modelValue', name)
+      }
+
+      watch(
+        () => props.modelValue,
+        val => {
+          checkValue.value = val
+        }
+      )
+
+      return {
+        slotList,
+        handleChange,
+        checkValue
+      }
+    }
+  })
+</script>
+<template>
+  <div class="dk-radio-group">
+    <div class="dk-radio-group__inner">
+      <div class="dk-radio-group__content">
+        <div class="dk-radio-group__list">
+          <div v-for="item in slotList" :key="item.name" class="dk-radio-group__item">
+            <dk-radio
+              v-model="checkValue"
+              :label="item.label"
+              :name="item.name"
+              v-bind="item"
+              @change="handleChange"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/components/dkswitch/index.ts
+++ b/packages/components/dkswitch/index.ts
@@ -1,0 +1,7 @@
+import mySwitch from './src/switch.vue'
+
+import { withInstall } from '../_utils/index'
+
+export const DkSwitch = withInstall(mySwitch)
+
+export type switchInstance = InstanceType<typeof mySwitch>

--- a/packages/components/dkswitch/src/props.ts
+++ b/packages/components/dkswitch/src/props.ts
@@ -41,7 +41,28 @@ export const switchProps = {
    * @default #C0CCDA
    * @description Switch off color
    */
-  uncheckedColor: setColorProp('#C0CCDA')
+  uncheckedColor: setColorProp('#C0CCDA'),
+  /**
+   * @name checkedText
+   * @type string
+   * @default ''
+   * @description Checked text
+   */
+  checkedText: setStringProp(''),
+  /**
+   * @name unCheckedText
+   * @type string
+   * @default ''
+   * @description Unchecked text
+   */
+  uncheckedText: setStringProp(''),
+  /**
+   * @name width 
+   * @type string | number
+   * @default 40px
+   * @description Switch width
+   */
+  width: setStringProp('40px')
 }
 
 export type SwitchPropsType = ExtractPropTypes<typeof switchProps>

--- a/packages/components/dkswitch/src/props.ts
+++ b/packages/components/dkswitch/src/props.ts
@@ -1,0 +1,33 @@
+import { setBooleanProps, setStringProp } from '../../_utils'
+import { type ExtractPropTypes } from 'vue'
+import type { dkPlusSize } from '../../_interface'
+import { DK_SIZE } from '../../_tokens'
+
+export const switchProps = {
+  /**
+   * @name modelValue
+   * @type boolean
+   * @default false
+   * @description Selected status of the switch
+   */
+  modelValue: setBooleanProps(false),
+  /**
+   * @name disabled
+   * @type boolean
+   * @default false
+   * @description Whether the switch is disabled
+   */
+  disabled: setBooleanProps(false),
+  /**
+   * @name size
+   * @param { string }  [large]
+   * @param { string }  [medium]
+   * @param { string }  [small]
+   * @param { string }  [mini]
+   */
+  size: setStringProp<dkPlusSize>(null, (val: dkPlusSize) => {
+    return DK_SIZE.includes(val)
+  })
+}
+
+export type SwitchPropsType = ExtractPropTypes<typeof switchProps>

--- a/packages/components/dkswitch/src/props.ts
+++ b/packages/components/dkswitch/src/props.ts
@@ -1,4 +1,4 @@
-import { setBooleanProps, setStringProp } from '../../_utils'
+import { setBooleanProps, setColorProp, setStringProp } from '../../_utils'
 import { type ExtractPropTypes } from 'vue'
 import type { dkPlusSize } from '../../_interface'
 import { DK_SIZE } from '../../_tokens'
@@ -27,7 +27,21 @@ export const switchProps = {
    */
   size: setStringProp<dkPlusSize>(null, (val: dkPlusSize) => {
     return DK_SIZE.includes(val)
-  })
+  }),
+  /**
+   * @name checkedColor
+   * @type string
+   * @default #409EFF
+   * @description Switch on color
+   */
+  checkedColor: setColorProp('#409EFF'),
+  /**
+   * @name unCheckedColor
+   * @type string
+   * @default #C0CCDA
+   * @description Switch off color
+   */
+  uncheckedColor: setColorProp('#C0CCDA')
 }
 
 export type SwitchPropsType = ExtractPropTypes<typeof switchProps>

--- a/packages/components/dkswitch/src/switch.vue
+++ b/packages/components/dkswitch/src/switch.vue
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { defineComponent, reactive, toRefs, watch, ref } from 'vue'
+  import { switchProps } from './props'
+  import { getSwitch } from '../../_hooks'
+  export default defineComponent({
+    name: 'DkSwitch',
+    props: switchProps,
+    emits: ['change', 'update:modelValue'],
+    setup(props, { emit }) {
+      const { classList, styleList } = getSwitch(props)
+
+      const data = reactive({
+        modelValue: props.modelValue,
+        disabled: props.disabled
+      })
+
+      const methods = {
+        handleChange: (e: Event): void => {
+          if (data.disabled) return
+          const target = e.target as HTMLInputElement
+          data.modelValue = target.checked
+
+          emit('update:modelValue', data.modelValue)
+          emit('change', data.modelValue)
+        }
+      }
+
+      const switchRef = ref<HTMLInputElement>()
+
+      watch(
+        () => props.modelValue,
+        val => {
+          data.modelValue = val
+
+          if (switchRef.value) {
+            switchRef.value.checked = val
+          }
+        },
+        {
+          immediate: true
+        }
+      )
+
+      return {
+        classList,
+        styleList,
+        ...toRefs(data),
+        ...methods,
+        switchRef
+      }
+    }
+  })
+</script>
+<template>
+  <div :class="classList" :style="styleList">
+    <label class="dk-switch-wrapper" @change="handleChange">
+      <input ref="switchRef" type="checkbox" class="dk-switch_inner" />
+      <span class="dk-switch_slider"></span>
+      <span class="dk-switch_title">
+        <slot></slot>
+      </span>
+    </label>
+  </div>
+</template>

--- a/packages/components/dkswitch/src/switch.vue
+++ b/packages/components/dkswitch/src/switch.vue
@@ -11,7 +11,10 @@
 
       const data = reactive({
         modelValue: props.modelValue,
-        disabled: props.disabled
+        disabled: props.disabled,
+        checkedText: props.checkedText,
+        uncheckedText: props.uncheckedText,
+        checkText: props.uncheckedText
       })
 
       const methods = {
@@ -29,8 +32,9 @@
       watch(
         () => props.modelValue,
         val => {
-          if(data.disabled) return
+          if (data.disabled) return
           data.modelValue = val
+          data.checkText = val ? data.checkedText : data.uncheckedText
 
           if (switchRef.value) {
             switchRef.value.checked = val
@@ -54,11 +58,13 @@
 <template>
   <div :class="classList" :style="styleList">
     <label class="dk-switch-wrapper" @change="handleChange">
-      <input ref="switchRef" type="checkbox" class="dk-switch_inner" />
-      <span class="dk-switch_slider"></span>
-      <span class="dk-switch_title">
-        <slot></slot>
-      </span>
+      <input ref="switchRef" type="checkbox" class="dk-switch_inner" v-bind="$attrs" />
+      <div class="dk-switch_slider" area-hidden="true">
+        <span class="dk-switch_title">
+          {{ checkText }}
+          <slot></slot>
+        </span>
+      </div>
     </label>
   </div>
 </template>

--- a/packages/components/dkswitch/src/switch.vue
+++ b/packages/components/dkswitch/src/switch.vue
@@ -18,10 +18,9 @@
         handleChange: (e: Event): void => {
           if (data.disabled) return
           const target = e.target as HTMLInputElement
-          data.modelValue = target.checked
 
-          emit('update:modelValue', data.modelValue)
-          emit('change', data.modelValue)
+          emit('update:modelValue', target.checked)
+          emit('change', target.checked)
         }
       }
 
@@ -30,6 +29,7 @@
       watch(
         () => props.modelValue,
         val => {
+          if(data.disabled) return
           data.modelValue = val
 
           if (switchRef.value) {

--- a/packages/components/global.d.ts
+++ b/packages/components/global.d.ts
@@ -25,6 +25,8 @@ declare module '@vue/runtime-core' {
     DkCollapse: typeof components.DkCollapse
     DkCollapseItem: typeof components.DkCollapseItem
     DkTransition: typeof components.DkTransition
+    DkRadio: typeof components.DkRadio
+    DkRadioGroup: typeof components.DkRadioGroup
   }
   export interface ImportMetaEnv {
     VITE_APP_BASE_API: string

--- a/packages/theme-chalk/index.scss
+++ b/packages/theme-chalk/index.scss
@@ -24,3 +24,4 @@
 @use './src/dkcheckboxgroup.scss';
 @use './src/dkradio.scss';
 @use './src/dkradiogroup.scss';
+@use './src/dkswitch.scss';

--- a/packages/theme-chalk/index.scss
+++ b/packages/theme-chalk/index.scss
@@ -23,3 +23,4 @@
 @use './src/dktransition.scss';
 @use './src/dkcheckboxgroup.scss';
 @use './src/dkradio.scss';
+@use './src/dkradiogroup.scss';

--- a/packages/theme-chalk/mixins/configuration/var-radio.scss
+++ b/packages/theme-chalk/mixins/configuration/var-radio.scss
@@ -1,5 +1,0 @@
-@use '../mixin.scss' as *;
-
-@include block('radio') {
-  --radio-font-size: 13px;
-}

--- a/packages/theme-chalk/src/dkradio.scss
+++ b/packages/theme-chalk/src/dkradio.scss
@@ -8,6 +8,7 @@
   @include block(wrapper) {
     cursor: pointer;
     display: inline-block;
+    white-space: nowrap;
     margin-right: 10px;
     font-family: Arial, sans-serif;
     font-size: 14px;
@@ -18,6 +19,7 @@
       padding-left: calc(var(--radio-size) + 10px);
       font-size: var(--radio-size);
       transition: all 0.1s ease-in-out;
+      color: #666;
     }
   }
 
@@ -28,9 +30,10 @@
     left: 0;
     width: var(--radio-size);
     height: var(--radio-size);
-    border: 2px solid #409eff;
+    border: 2px solid var(--radio-unchecked-color);
     border-radius: 50%;
-    &:before{
+    transition: all 0.1s ease-in-out;
+    &:before {
       content: '';
       width: 100%;
       height: 100%;
@@ -38,11 +41,11 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%) scale(0);
-      border: 2px solid #409eff;
+      border: 2px solid var(--radio-unchecked-color);
       border-radius: 50%;
       transition: all 0.1s ease-in-out;
     }
-    &:after{
+    &:after {
       content: '';
       width: 100%;
       height: 100%;
@@ -51,26 +54,29 @@
       left: 50%;
       transform: translate(-50%, -50%) scale(0);
       border-radius: 50%;
-      background-color: #409eff;
+      background-color: var(--radio-unchecked-color);
       opacity: 0;
       transition: all 0.1s ease-in-out;
     }
-
   }
 
   @include element(inner) {
     display: none;
-    &:checked + .dk-radio_circle:before{
-      background-color: #fff;
-      z-index: 1;
-      transform: translate(-50%, -50%) scale(.4);
-    }
-    &:checked + .dk-radio_circle:after{
-      opacity: 1;
-      transform: translate(-50%, -50%) scale(1.15);
-    }
-    &:checked + .dk-radio_circle + span{
-      color: #409eff;
+    &:checked + .dk-radio_circle {
+      border-color: var(--radio-checked-color);
+      &:before {
+        background-color: #fff;
+        z-index: 1;
+        transform: translate(-50%, -50%) scale(0.4);
+      }
+      &:after {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1.15);
+        background-color: var(--radio-checked-color);
+      }
+      & + span {
+        color: var(--radio-checked-color);
+      }
     }
   }
 

--- a/packages/theme-chalk/src/dkradio.scss
+++ b/packages/theme-chalk/src/dkradio.scss
@@ -4,6 +4,8 @@
   display: inline-block;
   user-select: none;
   margin-right: 10px;
+  font-family: Arial, sans-serif;
+  align-items: center;
 
   &:hover{
     .dk-radio_circle {
@@ -97,6 +99,31 @@
     @include block('>*radio') {
       @include block(wrapper) {
         cursor: not-allowed;
+      }
+    }
+  }
+  
+  @include element(border){
+    padding: 5px 10px;
+    span{
+      &:before{
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: calc(100% + 20px);
+        height: calc(100% + 10px);
+        border: 1px solid var(--radio-unchecked-color);
+        border-radius: 4px;
+        transition: all 0.1s ease-in-out;
+      }
+    }
+    .dk-radio_inner{
+      &:checked + .dk-radio_circle + span{
+        &:before{
+          border-color: var(--radio-checked-color);
+        }
       }
     }
   }

--- a/packages/theme-chalk/src/dkradio.scss
+++ b/packages/theme-chalk/src/dkradio.scss
@@ -5,6 +5,17 @@
   user-select: none;
   margin-right: 10px;
 
+  &:hover{
+    .dk-radio_circle {
+      border-color: var(--radio-hover-color);
+    }
+    &.dk-radio_disabled {
+      .dk-radio_circle {
+        border-color: var(--radio-unchecked-color);
+      }
+    }
+  }
+
   @include block(wrapper) {
     cursor: pointer;
     display: inline-block;

--- a/packages/theme-chalk/src/dkradio.scss
+++ b/packages/theme-chalk/src/dkradio.scss
@@ -1,5 +1,4 @@
 @use '../mixins/mixin.scss' as *;
-@use '../mixins//configuration/var-radio.scss' as *;
 
 @include block(radio) {
   display: inline-block;
@@ -8,7 +7,6 @@
 
   @include block(wrapper) {
     cursor: pointer;
-    // font-size: var(--radio-font-size);
     display: inline-block;
     margin-right: 10px;
     font-family: Arial, sans-serif;
@@ -17,65 +15,62 @@
     position: relative;
     span {
       position: relative;
-      padding-left: 20px;
-      &:before {
-        content: '';
-        position: absolute;
-        top: 2px;
-        left: 0;
-        width: 10px;
-        height: 10px;
-        border: 2px solid #409eff;
-        border-radius: 50%;
-        transform: scale(0);
-        transition: transform 0.2s ease-in-out;
-      }
-      &:after {
-        content: '';
-        position: absolute;
-        top: 3px;
-        left: 1px;
-        width: 12px;
-        height: 12px;
-        border-radius: 50%;
-        background-color: #409eff;
-        opacity: 0;
-        transform: scale(0);
-        transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
-      }
+      padding-left: calc(var(--radio-size) + 10px);
+      font-size: var(--radio-size);
+      transition: all 0.1s ease-in-out;
     }
   }
 
   @include element(circle) {
     position: absolute;
-    top: 2px;
+    top: 50%;
+    transform: translateY(-50%);
     left: 0;
-    width: 10px;
-    height: 10px;
+    width: var(--radio-size);
+    height: var(--radio-size);
     border: 2px solid #409eff;
     border-radius: 50%;
+    &:before{
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0);
+      border: 2px solid #409eff;
+      border-radius: 50%;
+      transition: all 0.1s ease-in-out;
+    }
+    &:after{
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0);
+      border-radius: 50%;
+      background-color: #409eff;
+      opacity: 0;
+      transition: all 0.1s ease-in-out;
+    }
+
   }
 
   @include element(inner) {
     display: none;
-    &:checked + span:before {
-      background-color: #409eff;
-      transform: scale(1);
-      content: '';
-      position: absolute;
-      top: 5px;
-      left: 3px;
-      z-index: 1;
-      width: 4px;
-      height: 4px;
-      border-radius: 50%;
+    &:checked + .dk-radio_circle:before{
       background-color: #fff;
-      transform: scale(1);
-      transition: transform 0.2s ease-in-out;
+      z-index: 1;
+      transform: translate(-50%, -50%) scale(.4);
     }
-    &:checked + span:after {
+    &:checked + .dk-radio_circle:after{
       opacity: 1;
-      transform: scale(1);
+      transform: translate(-50%, -50%) scale(1.15);
+    }
+    &:checked + .dk-radio_circle + span{
+      color: #409eff;
     }
   }
 

--- a/packages/theme-chalk/src/dkradiogroup.scss
+++ b/packages/theme-chalk/src/dkradiogroup.scss
@@ -3,5 +3,6 @@
 @include block(radio-group){
   @include element(list){
     display: flex;
+    flex-wrap: wrap;
   }
 }

--- a/packages/theme-chalk/src/dkradiogroup.scss
+++ b/packages/theme-chalk/src/dkradiogroup.scss
@@ -1,0 +1,7 @@
+@use '../mixins/mixin.scss' as *;
+
+@include block(radio-group){
+  @include element(list){
+    display: flex;
+  }
+}

--- a/packages/theme-chalk/src/dkswitch.scss
+++ b/packages/theme-chalk/src/dkswitch.scss
@@ -1,27 +1,44 @@
 @use '../mixins/mixin.scss' as *;
 
 @include block(switch) {
-  width: var(--switch-size);
-  height: calc(var(--switch-size) / 2);
+  width: var(--switch-width);
+  height: var(--switch-height);
   cursor: pointer;
   @include block(wrapper) {
-    width: var(--switch-size);
-    height: calc(var(--switch-size) / 2);
+    width: var(--switch-width);
+    height: var(--switch-height);
     position: absolute;
   }
   @include element(slider) {
-    width: inherit;
+    width: var(--switch-width);
+    // width: fit-content;
+    // min-width: var(--switch-width);
     height: inherit;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+    border-radius: var(--switch-height);
+    overflow: hidden;
+    
+    .dk-switch_title{
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      transform: translateX(30%);
+      transition: all 0.2s;
+    }
+
     &:before {
       content: '';
       display: inline-block;
-      width: var(--switch-size);
-      height: calc(var(--switch-size) / 2);
-      border-radius: calc(var(--switch-size) / 2);
+      width: 100%;
+      height: var(--switch-height);
+      border-radius: var(--switch-height);
       position: absolute;
       top: 0;
       background-color: var(--switch-unchecked-color);
@@ -29,11 +46,12 @@
       transition: all 0.2s;
       cursor: pointer;
     }
+
     &:after {
       content: '';
       display: inline-block;
-      width: calc(var(--switch-size) / 2 - 4px);
-      height: calc(var(--switch-size) / 2 - 4px);
+      width: calc(var(--switch-height) - 4px);
+      height: calc(var(--switch-height) - 4px);
       background-color: #fff;
       border-radius: 50%;
       position: absolute;
@@ -41,13 +59,13 @@
       transform: translateY(-50%);
       left: 2px;
       transition: all 0.2s;
-      z-index: 1;
+      z-index: 2;
       cursor: pointer;
     }
   }
   @include element(inner) {
-    width: var(--switch-size);
-    height: calc(var(--switch-size) / 2);
+    width: var(--switch-width);
+    height: var(--switch-height);
     cursor: pointer;
     position: absolute;
     top: 0;
@@ -55,13 +73,25 @@
     z-index: 2;
     opacity: 0;
     &:checked + .dk-switch_slider {
+      .dk-switch_title{
+        transform: translateX(-30%);
+      }
       &:before {
         background-color: var(--switch-checked-color);
       }
       &:after {
-        left: calc(100% - var(--switch-size) / 2 + 2px);
+        left: calc(100% - var(--switch-height) + 2px);
       }
     }
+  }
+
+  @include element(title){
+    position: relative;
+    z-index: 1;
+    font-size: 12px;
+    color: #fff;
+    padding: 0 6px;
+    transition: all 0.2s;
   }
 
   @include element(disabled){

--- a/packages/theme-chalk/src/dkswitch.scss
+++ b/packages/theme-chalk/src/dkswitch.scss
@@ -1,0 +1,83 @@
+@use '../mixins/mixin.scss' as *;
+
+@include block(switch) {
+  width: var(--switch-size);
+  height: calc(var(--switch-size) / 2);
+  cursor: pointer;
+  @include block(wrapper) {
+    width: var(--switch-size);
+    height: calc(var(--switch-size) / 2);
+    position: absolute;
+  }
+  @include element(slider) {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    &:before {
+      content: '';
+      display: inline-block;
+      width: var(--switch-size);
+      height: calc(var(--switch-size) / 2);
+      border-radius: calc(var(--switch-size) / 2);
+      position: absolute;
+      top: 0;
+      background-color: #dcdfe6;
+      left: 0;
+      transition: all 0.2s;
+      cursor: pointer;
+    }
+    &:after {
+      content: '';
+      display: inline-block;
+      width: calc(var(--switch-size) / 2 - 4px);
+      height: calc(var(--switch-size) / 2 - 4px);
+      background-color: #fff;
+      border-radius: 50%;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      left: 2px;
+      transition: all 0.2s;
+      z-index: 1;
+      cursor: pointer;
+    }
+  }
+  @include element(inner) {
+    width: var(--switch-size);
+    height: calc(var(--switch-size) / 2);
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    opacity: 0;
+    &:checked + .dk-switch_slider {
+      &:before {
+        background-color: #409eff;
+      }
+      &:after {
+        left: calc(100% - var(--switch-size) / 2 + 2px);
+      }
+    }
+  }
+
+  @include element(disabled){
+    opacity: 0.6;
+    * {
+      cursor: not-allowed;
+    }
+    .dk-switch_inner{
+      &:checked + .dk-switch_slider{
+        &:before {
+          background-color: #dcdfe6;
+        }
+        &:after {
+          left: 2px;
+        }
+      }
+    }
+  }
+}

--- a/packages/theme-chalk/src/dkswitch.scss
+++ b/packages/theme-chalk/src/dkswitch.scss
@@ -2,22 +2,25 @@
 
 @include block(switch) {
   width: var(--switch-width);
+  min-width: var(--switch-min-width);
   height: var(--switch-height);
   cursor: pointer;
   @include block(wrapper) {
+    display: block;
     width: var(--switch-width);
+    min-width: var(--switch-min-width);
     height: var(--switch-height);
     position: absolute;
   }
   @include element(slider) {
     width: var(--switch-width);
-    // width: fit-content;
-    // min-width: var(--switch-width);
+    min-width: calc(var(--switch-min-width) - 20px);
     height: inherit;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    padding: 0 10px;
+    position: relative;
+    // top: 50%;
+    // left: 50%;
+    // transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -29,7 +32,7 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      transform: translateX(30%);
+      transform: translateX(6px);
       transition: all 0.2s;
     }
 
@@ -64,8 +67,8 @@
     }
   }
   @include element(inner) {
-    width: var(--switch-width);
-    height: var(--switch-height);
+    width: 100%;
+    height: 100%;
     cursor: pointer;
     position: absolute;
     top: 0;
@@ -74,7 +77,7 @@
     opacity: 0;
     &:checked + .dk-switch_slider {
       .dk-switch_title{
-        transform: translateX(-30%);
+        transform: translateX(-6px);
       }
       &:before {
         background-color: var(--switch-checked-color);

--- a/packages/theme-chalk/src/dkswitch.scss
+++ b/packages/theme-chalk/src/dkswitch.scss
@@ -24,7 +24,7 @@
       border-radius: calc(var(--switch-size) / 2);
       position: absolute;
       top: 0;
-      background-color: #dcdfe6;
+      background-color: var(--switch-unchecked-color);
       left: 0;
       transition: all 0.2s;
       cursor: pointer;
@@ -56,7 +56,7 @@
     opacity: 0;
     &:checked + .dk-switch_slider {
       &:before {
-        background-color: #409eff;
+        background-color: var(--switch-checked-color);
       }
       &:after {
         left: calc(100% - var(--switch-size) / 2 + 2px);

--- a/packages/theme-chalk/src/index.scss
+++ b/packages/theme-chalk/src/index.scss
@@ -23,3 +23,4 @@
 @use 'dktransition.scss';
 @use 'dkcheckboxgroup.scss';
 @use 'dkradio.scss';
+@use 'dkradiogroup.scss';

--- a/packages/theme-chalk/src/index.scss
+++ b/packages/theme-chalk/src/index.scss
@@ -24,3 +24,4 @@
 @use 'dkcheckboxgroup.scss';
 @use 'dkradio.scss';
 @use 'dkradiogroup.scss';
+@use 'dkswitch.scss';

--- a/play/views/component/DkRadio/DkRadio.vue
+++ b/play/views/component/DkRadio/DkRadio.vue
@@ -1,24 +1,94 @@
-<script lang='ts'>
-  import { defineComponent, ref } from 'vue';
+<script lang="ts">
+  import { defineComponent, ref } from 'vue'
   export default defineComponent({
     name: 'DkRadioComp',
     setup() {
-      const radioValue = ref('radio2');
+      const radioValue = ref('radio2')
       const handleChange = (name: string): void => {
+        console.log(name)
+      }
+      const groupValue = ref('radio2')
+      const handleGroupChange = (name: string): void => {
         console.log(name);
+        
       }
       return {
         radioValue,
-        handleChange
-      };
+        handleChange,
+        groupValue,
+        handleGroupChange
+      }
     }
-  });
+  })
 </script>
 <template>
-  <dk-radio v-model="radioValue" label="option 1 - disabled" name="radio1-disabled" disabled size="large" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 1 - large" name="radio1" size="large" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 2 - medium" name="radio2" size="medium" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 3 - small" name="radio3" size="small" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 3 - default" name="radio3" size="default" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 4 - mini" name="radio4" size="mini" @change="handleChange" />
+  <div class="box">
+    <h4>基础使用</h4>
+    <div class="list">
+      <dk-radio
+        v-model="radioValue"
+        label="option 1 - disabled"
+        name="radio1-disabled"
+        disabled
+        size="large"
+        @change="handleChange"
+      />
+      <dk-radio
+        v-model="radioValue"
+        label="option 1 - large"
+        name="radio1"
+        size="large"
+        @change="handleChange"
+      />
+      <dk-radio
+        v-model="radioValue"
+        label="option 2 - medium"
+        name="radio2"
+        size="medium"
+        @change="handleChange"
+      />
+      <dk-radio
+        v-model="radioValue"
+        label="option 3 - small"
+        name="radio3"
+        size="small"
+        @change="handleChange"
+      />
+      <dk-radio
+        v-model="radioValue"
+        label="option 3 - default"
+        name="radio3"
+        size="default"
+        @change="handleChange"
+      />
+      <dk-radio
+        v-model="radioValue"
+        label="option 4 - mini"
+        name="radio4"
+        size="mini"
+        @change="handleChange"
+      />
+    </div>
+  </div>
+  <div class="box">
+    <h4>group 组</h4>
+    <dk-radio-group v-model="groupValue" @change="handleGroupChange">
+      <dk-radio label="option 1" name="radio1" size="large" disabled />
+      <dk-radio label="option 2" name="radio2" />
+      <dk-radio label="option 3" name="radio3" />
+    </dk-radio-group>
+  </div>
 </template>
+
+<style lang="scss" scoped>
+  .box {
+    margin-bottom: 20px;
+    .list {
+      display: flex;
+      flex-wrap: wrap;
+      .dk-radio {
+        margin-right: 20px;
+      }
+    }
+  }
+</style>

--- a/play/views/component/DkRadio/DkRadio.vue
+++ b/play/views/component/DkRadio/DkRadio.vue
@@ -15,7 +15,10 @@
   });
 </script>
 <template>
-  <dk-radio v-model="radioValue" label="option 1" name="radio1" disabled @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 2" name="radio2" @change="handleChange" />
-  <dk-radio v-model="radioValue" label="option 3" name="radio3" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 1 - disabled" name="radio1-disabled" disabled size="large" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 1 - large" name="radio1" size="large" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 2 - medium" name="radio2" size="medium" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 3 - small" name="radio3" size="small" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 3 - default" name="radio3" size="default" @change="handleChange" />
+  <dk-radio v-model="radioValue" label="option 4 - mini" name="radio4" size="mini" @change="handleChange" />
 </template>

--- a/play/views/component/DkRadio/DkRadio.vue
+++ b/play/views/component/DkRadio/DkRadio.vue
@@ -58,7 +58,6 @@
         v-model="radioValue"
         label="option 3 - default"
         name="radio3"
-        size="default"
         @change="handleChange"
       />
       <dk-radio
@@ -73,9 +72,9 @@
   <div class="box">
     <h4>group 组</h4>
     <dk-radio-group v-model="groupValue" @change="handleGroupChange">
-      <dk-radio label="option 1" name="radio1" size="large" disabled />
+      <dk-radio label="option 1" name="radio1" disabled />
       <dk-radio label="option 2" name="radio2" />
-      <dk-radio label="option 3" name="radio3" />
+      <dk-radio label="option 3" name="radio3" checked-color="#ee4f4f" unchecked-color="#ce853f" />
     </dk-radio-group>
   </div>
 </template>

--- a/play/views/component/DkRadio/DkRadio.vue
+++ b/play/views/component/DkRadio/DkRadio.vue
@@ -73,7 +73,7 @@
     <h4>group 组</h4>
     <dk-radio-group v-model="groupValue" @change="handleGroupChange">
       <dk-radio label="option 1" name="radio1" disabled />
-      <dk-radio label="option 2" name="radio2" />
+      <dk-radio label="option 2" name="radio2" border />
       <dk-radio label="option 3" name="radio3" checked-color="#ee4f4f" unchecked-color="#ce853f" />
     </dk-radio-group>
   </div>

--- a/play/views/component/DkSwitch/DkSwitch.vue
+++ b/play/views/component/DkSwitch/DkSwitch.vue
@@ -14,28 +14,52 @@
   <div class="box">
     <h4>基础使用</h4>
     <div class="switch-list">
-      <dk-switch v-model="checked" disabled size="large" />
-      <dk-switch
-        v-model="checked"
-        size="medium"
-        checked-color="#359a35"
-        unchecked-color="#d33f3f"
-      />
+      <dk-switch v-model="checked" />
+    </div>
+  </div>
+  <div class="box">
+    <h4>尺寸</h4>
+    <div class="switch-list">
+      <dk-switch v-model="checked" size="large" />
+      <dk-switch v-model="checked" size="medium" />
       <dk-switch v-model="checked" size="small" />
-      <dk-switch v-model="checked" size="mini" />
+      <dk-switch v-model="checked" size="mini"></dk-switch>
+    </div>
+  </div>
+  <div class="box">
+    <h4>选中颜色</h4>
+    <div class="switch-list">
+      <dk-switch v-model="checked" checked-color="#359a35" unchecked-color="#d33f3f" />
+    </div>
+  </div>
+  <div class="box">
+    <h4>禁用</h4>
+    <div class="switch-list">
+      <dk-switch v-model="checked" disabled />
+    </div>
+  </div>
+  <div class="box">
+    <h4>文案设置</h4>
+    <div class="switch-list">
+      <dk-switch v-model="checked" checked-text="是" unchecked-text="否" />
+    </div>
+    <div class="switch-list">
+      <dk-switch v-model="checked" checked-text="Y" unchecked-text="N" width="100px" />
+      <dk-switch v-model="checked" checked-text="是是是是是是" unchecked-text="否否否否否否" />
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
   .box {
-    padding: 20px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     .switch-list {
       display: flex;
       align-items: center;
-      .dk-switch {
-        margin-right: 20px;
-      }
+      gap: 10px;
     }
   }
 </style>

--- a/play/views/component/DkSwitch/DkSwitch.vue
+++ b/play/views/component/DkSwitch/DkSwitch.vue
@@ -1,28 +1,33 @@
-<script lang='ts'>
-  import { defineComponent, ref } from 'vue';
+<script lang="ts">
+  import { defineComponent, ref } from 'vue'
   export default defineComponent({
     name: 'DkSwitchComp',
     setup() {
-      const checked = ref(false);
+      const checked = ref(false)
       return {
         checked
-      };
+      }
     }
-  });
+  })
 </script>
 <template>
   <div class="box">
     <h4>基础使用</h4>
     <div class="switch-list">
       <dk-switch v-model="checked" disabled size="large" />
-      <dk-switch v-model="checked" size="medium" />
+      <dk-switch
+        v-model="checked"
+        size="medium"
+        checked-color="#359a35"
+        unchecked-color="#d33f3f"
+      />
       <dk-switch v-model="checked" size="small" />
       <dk-switch v-model="checked" size="mini" />
     </div>
   </div>
 </template>
 
-<style lang='scss' scoped>
+<style lang="scss" scoped>
   .box {
     padding: 20px;
     .switch-list {

--- a/play/views/component/DkSwitch/DkSwitch.vue
+++ b/play/views/component/DkSwitch/DkSwitch.vue
@@ -1,0 +1,36 @@
+<script lang='ts'>
+  import { defineComponent, ref } from 'vue';
+  export default defineComponent({
+    name: 'DkSwitchComp',
+    setup() {
+      const checked = ref(false);
+      return {
+        checked
+      };
+    }
+  });
+</script>
+<template>
+  <div class="box">
+    <h4>基础使用</h4>
+    <div class="switch-list">
+      <dk-switch v-model="checked" disabled size="large" />
+      <dk-switch v-model="checked" size="medium" />
+      <dk-switch v-model="checked" size="small" />
+      <dk-switch v-model="checked" size="mini" />
+    </div>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+  .box {
+    padding: 20px;
+    .switch-list {
+      display: flex;
+      align-items: center;
+      .dk-switch {
+        margin-right: 20px;
+      }
+    }
+  }
+</style>

--- a/play/views/component/DkSwitch/DkSwitch.vue
+++ b/play/views/component/DkSwitch/DkSwitch.vue
@@ -45,7 +45,7 @@
     </div>
     <div class="switch-list">
       <dk-switch v-model="checked" checked-text="Y" unchecked-text="N" width="100px" />
-      <dk-switch v-model="checked" checked-text="是是是是是是" unchecked-text="否否否否否否" />
+      <dk-switch v-model="checked" checked-text="是是是是是是" unchecked-text="否否否否否否否否否否否否否否否否否否" width="100px" />
     </div>
   </div>
 </template>

--- a/play/views/component/DkSwitch/page.ts
+++ b/play/views/component/DkSwitch/page.ts
@@ -1,0 +1,5 @@
+export default {
+  path: '/DkSwitch',
+  order: 16,
+  title: 'DkSwitch 开关' 
+}

--- a/play/views/component/index/index.vue
+++ b/play/views/component/index/index.vue
@@ -48,7 +48,7 @@
           <li v-for="(item, ind) in routerList" :key="ind">
             <router-link
               :to="item.path"
-              :style="$route.path === item.path ? 'color: #34ab98;' : 'color: #ccc;'"
+              :style="$route.path === item.path ? 'color: #34ab98;' : 'color: #aaa;'"
             >
               {{ item.name }}
             </router-link>

--- a/play/views/component/index/index.vue
+++ b/play/views/component/index/index.vue
@@ -17,14 +17,16 @@
       onMounted(() => {
         allRoutes.value = router.getRoutes()
 
-        data.routerList = allRoutes.value.map(item => {
-          if(item.path === '/index') return
-          return {
-            name: item.meta.title,
-            path: item.path,
-            order: item.meta.order || 0
-          }
-        }).filter(item => !!item) as Item[]
+        data.routerList = allRoutes.value
+          .map(item => {
+            if (item.path === '/index') return
+            return {
+              name: item.meta.title,
+              path: item.path,
+              order: item.meta.order || 0
+            }
+          })
+          .filter(item => !!item) as Item[]
         data.routerList.sort((a, b) => {
           return a.order - b.order
         })
@@ -108,7 +110,7 @@
       display: flex;
 
       .index-conten-left {
-        width: 124px;
+        width: 200px;
 
         ul {
           list-style: none;

--- a/play/views/component/index/index.vue
+++ b/play/views/component/index/index.vue
@@ -50,7 +50,7 @@
               :to="item.path"
               :style="$route.path === item.path ? 'color: #34ab98;' : 'color: #aaa;'"
             >
-              {{ item.name }}
+              {{ ind + 1 }} - {{ item.name }}
             </router-link>
           </li>
         </ul>


### PR DESCRIPTION
## Pull Request 概述

这个 Pull Request 解决了以下问题/添加了以下功能：

## 改动的细节

- [x] 添加了`radio`的`size`尺寸 支持 `large` `midum` `small` `mini`等尺寸，默认 `small`
- [x] 优化了`radio`的样式
- [x] 新增`dk-radio-group`单选框组 组件 
- [x] 添加radio边框属性 
- [x] 补全raidio文档 
- [x] 优化代码块的展开收起 

## 测试

我已经进行了以下测试来确保组件的正常显示和功能：

- [x] 在不同浏览器中进行了测试
- [x] 在不同屏幕分辨率下进行了测试
- [x] 确保组件在不同页面和状态下显示正确